### PR TITLE
Add unit tests for utilities

### DIFF
--- a/src/test/java/com/baerchen/jutils/runtime/ApiCredentialsTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/ApiCredentialsTest.java
@@ -1,0 +1,36 @@
+import com.baerchen.jutils.runtime.control.ValidationReport;
+import com.baerchen.jutils.runtime.entity.ApiCredentials;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+class ApiCredentialsTest {
+
+    static class DummyCreds extends ApiCredentials {
+        DummyCreds(Map<String,String> creds, List<String> keys) {
+            super(creds, keys);
+        }
+
+        @Override
+        public ValidationReport<Map<String, String>> validate() {
+            return ValidationReport.<Map<String, String>>builder()
+                    .valid(containsAllKeys(getKeys()))
+                    .cause("validation")
+                    .data(getCredentials().toString())
+                    .build();
+        }
+    }
+
+    @Test
+    void containsAllAnyAndMissing() {
+        Map<String,String> map = Map.of("a","1", "b", null);
+        DummyCreds creds = new DummyCreds(map, List.of("a","b","c"));
+
+        assertFalse(creds.containsAllKeys(List.of("a","b")));
+        assertTrue(creds.containsAnyKey(List.of("b","c")));
+        List<String> missing = creds.missingKeys(List.of("b","c"));
+        assertEquals(List.of("b","c"), missing);
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/ApiQueryParamsTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/ApiQueryParamsTest.java
@@ -1,0 +1,32 @@
+import com.baerchen.jutils.runtime.control.ApiQueryParams;
+import com.baerchen.jutils.runtime.control.ValidationReport;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+class ApiQueryParamsTest {
+
+    @Test
+    void validateDetectsMissingRequiredParams() {
+        ApiQueryParams params = ApiQueryParams.builder()
+                .params(Map.of("foo", "bar"))
+                .requiredKeys(List.of("foo", "bar"))
+                .build();
+
+        ValidationReport<Map<String, String>> report = params.validate();
+        assertFalse(report.isValid());
+        assertTrue(report.getCause().contains("bar"));
+    }
+
+    @Test
+    void toQueryStringEncodesAndIgnoresNulls() {
+        ApiQueryParams params = ApiQueryParams.builder()
+                .params(Map.of("f o", "b a r", "baz", null))
+                .build();
+
+        String qs = params.toQueryString();
+        assertEquals("f%20o=b%20a%20r", qs);
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/ApiServiceImplTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/ApiServiceImplTest.java
@@ -1,0 +1,58 @@
+import com.baerchen.jutils.runtime.boundary.ApiServiceImpl;
+import com.baerchen.jutils.runtime.control.ApiQueryParams;
+import com.baerchen.jutils.runtime.entity.ApiCallResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiServiceImplTest {
+
+    @Test
+    void executeGetRequestReturnsInvalidWhenParamsInvalid() throws Exception {
+        ApiServiceImpl service = new ApiServiceImpl();
+        ApiQueryParams params = ApiQueryParams.builder()
+                .params(Map.of())
+                .requiredKeys(List.of("a"))
+                .build();
+
+        WebClient client = WebClient.builder().exchangeFunction(r -> Mono.empty()).build();
+
+        ApiCallResult<String> result = service.executeGetRequest("step", "http://example.com", params, client, String.class, true);
+        assertFalse(result.getValidationReport().isValid());
+        assertNull(result.getResponseEntity().getBody());
+    }
+
+    @Test
+    void executeGetRequestAppendsQuery() throws Exception {
+        AtomicReference<URI> captured = new AtomicReference<>();
+        ExchangeFunction function = request -> {
+            captured.set(request.url());
+            ClientResponse response = ClientResponse.create(HttpStatus.OK)
+                    .header("Content-Type", "text/plain;charset=UTF-8")
+                    .body("ok")
+                    .build();
+            return Mono.just(response);
+        };
+        WebClient client = WebClient.builder().exchangeFunction(function).build();
+
+        ApiServiceImpl service = new ApiServiceImpl();
+        ApiQueryParams params = ApiQueryParams.builder()
+                .params(Map.of("a", "1"))
+                .requiredKeys(List.of("a"))
+                .build();
+        ApiCallResult<String> result = service.executeGetRequest("s", "http://e.com/api", params, client, String.class, true);
+        assertEquals("http://e.com/api?a=1", captured.get().toString());
+        assertEquals("ok", result.getResponseEntity().getBody());
+        assertTrue(result.getValidationReport().isValid());
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/LoggingAspectTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/LoggingAspectTest.java
@@ -1,0 +1,30 @@
+import com.baerchen.jutils.runtime.control.Loggable;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Component;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class LoggingAspectTest {
+
+    @Autowired
+    DummyComponent component;
+
+    @Test
+    void stepIsPutIntoMdcDuringCall() {
+        String inside = component.run("x");
+        assertEquals("x", inside);
+        assertNull(MDC.get("step"));
+    }
+
+    @Component
+    static class DummyComponent {
+        @Loggable(logParams = false, logResult = false)
+        public String run(String step) {
+            return MDC.get("step");
+        }
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/MappableTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/MappableTest.java
@@ -1,0 +1,25 @@
+import com.baerchen.jutils.runtime.entity.Mappable;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MappableTest {
+    static class BadMappable implements Mappable {
+        boolean valid;
+        BadMappable(boolean valid){this.valid = valid;}
+        @Override
+        public boolean isValidInput(){return valid;}
+    }
+
+    @Test
+    void toSafeStringReturnsFallbackOnException() {
+        BadMappable m = new BadMappable(true);
+        String s = m.toSafeString(o -> { throw new RuntimeException("boom"); });
+        assertTrue(s.contains("Unserializable"));
+    }
+
+    @Test
+    void throwIfInvalidInputThrowsWhenInvalid() {
+        BadMappable m = new BadMappable(false);
+        assertThrows(IllegalStateException.class, m::throwIfInvalidInput);
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/ValidationReportTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/ValidationReportTest.java
@@ -1,0 +1,25 @@
+import com.baerchen.jutils.runtime.control.ValidationReport;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationReportTest {
+
+    @Test
+    void throwIfInvalidThrows() {
+        ValidationReport<Object> report = ValidationReport.builder()
+                .valid(false)
+                .cause("bad")
+                .data("d")
+                .build();
+        assertThrows(IllegalStateException.class, report::throwIfInvalid);
+    }
+
+    @Test
+    void throwIfInvalidDoesNothingWhenValid() {
+        ValidationReport<Object> report = ValidationReport.builder()
+                .valid(true)
+                .data("d")
+                .build();
+        assertDoesNotThrow(report::throwIfInvalid);
+    }
+}

--- a/src/test/java/com/baerchen/jutils/runtime/WebClientErrorBuilderTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/WebClientErrorBuilderTest.java
@@ -1,0 +1,34 @@
+import com.baerchen.jutils.runtime.control.WebClientErrorBuilder;
+import com.baerchen.jutils.runtime.entity.JUtilsClientException;
+import com.baerchen.jutils.runtime.entity.JUtilsServerException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebClientErrorBuilderTest {
+
+    @Test
+    void handle4xxReturnsClientException() {
+        ClientResponse response = ClientResponse.create(HttpStatus.BAD_REQUEST)
+                .body("bad request")
+                .header("Content-Type", "text/plain;charset=UTF-8")
+                .build();
+
+        assertThrows(JUtilsClientException.class, () ->
+                WebClientErrorBuilder.handle4xx("req", true).apply(response).block());
+    }
+
+    @Test
+    void handle5xxReturnsServerException() {
+        ClientResponse response = ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("error")
+                .header("Content-Type", "text/plain;charset=UTF-8")
+                .build();
+
+        assertThrows(JUtilsServerException.class, () ->
+                WebClientErrorBuilder.handle5xx("req", true).apply(response).block());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ApiQueryParams, ApiCredentials helpers and ValidationReport
- cover Mappable failure behaviour
- test WebClientErrorBuilder mappings
- verify ApiServiceImpl GET handling
- check LoggingAspect MDC management

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org...)*

------
https://chatgpt.com/codex/tasks/task_e_68584d817094832ebcdc6617dee06c9e