### PR TITLE
Fix validation cause and server exception message

### DIFF
--- a/src/main/java/com/baerchen/jutils/runtime/control/WebClientProviderWithApiKey.java
+++ b/src/main/java/com/baerchen/jutils/runtime/control/WebClientProviderWithApiKey.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public abstract class WebClientProviderWithApiKey implements Validable {
+public abstract class WebClientProviderWithApiKey implements Validable<Map<String, String>> {
 
     private final Map<String, String> credentials;
-    private List<String> keys;
+    private final List<String> keys;
 
     public WebClientProviderWithApiKey(Map<String, String> credentials, List<String> keys) {
         this.credentials = credentials;
@@ -18,15 +18,16 @@ public abstract class WebClientProviderWithApiKey implements Validable {
     public ValidationReport<Map<String, String>> validate() {
         String input = this.credentials.entrySet()
                 .stream()
-                .map(k -> String.format("[key,value]=[%s,%s]", k.getKey(), k.getValue()))
+                .map(e -> String.format("[key,value]=[%s,%s]", e.getKey(), e.getValue()))
                 .collect(Collectors.joining(", "));
-        String missingKeys = missingKeys(keys).stream().map( str -> str.toString()).collect(Collectors.joining(", "));
+        List<String> missing = missingKeys(keys);
+        boolean valid = missing.isEmpty();
 
-                 return ValidationReport.<Map<String, String>>builder()
-                        .valid(containsAllKeys(keys))
-                        .data(input)
-                        .cause(String.format("Missing key(s): [%s]", missingKeys))
-                        .build();
+        return ValidationReport.<Map<String, String>>builder()
+                .valid(valid)
+                .data(input)
+                .cause(valid ? null : String.format("Missing key(s): [%s]", String.join(", ", missing)))
+                .build();
     }
     private boolean containsAllKeys(List<String> requiredKeys) {
         return requiredKeys.stream()

--- a/src/main/java/com/baerchen/jutils/runtime/entity/JUtilsServerException.java
+++ b/src/main/java/com/baerchen/jutils/runtime/entity/JUtilsServerException.java
@@ -8,7 +8,7 @@ public class JUtilsServerException extends  JUtilsException {
     private final String requestBody;
 
     public JUtilsServerException(HttpStatusCode status, String message, String requestBody, byte[] body, Charset charset) {
-        super(String.format("Client error %s: %s", status.value(), new String(body, charset)));
+        super(String.format("Server error %s: %s", status.value(), new String(body, charset)));
         this.requestBody = requestBody;
     }
 

--- a/src/test/java/com/baerchen/jutils/runtime/WebClientProviderWithApiKeyTest.java
+++ b/src/test/java/com/baerchen/jutils/runtime/WebClientProviderWithApiKeyTest.java
@@ -1,0 +1,33 @@
+import com.baerchen.jutils.runtime.control.ValidationReport;
+import com.baerchen.jutils.runtime.control.WebClientProviderWithApiKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebClientProviderWithApiKeyTest {
+
+    static class DummyProvider extends WebClientProviderWithApiKey {
+        DummyProvider(Map<String, String> creds, List<String> keys) {
+            super(creds, keys);
+        }
+    }
+
+    @Test
+    void validateReturnsInvalidWhenKeysMissing() {
+        DummyProvider provider = new DummyProvider(Map.of("a", "1"), List.of("a", "b"));
+        ValidationReport<Map<String, String>> report = provider.validate();
+        assertFalse(report.isValid());
+        assertTrue(report.getCause().contains("b"));
+    }
+
+    @Test
+    void validateReturnsValidWhenAllKeysPresent() {
+        DummyProvider provider = new DummyProvider(Map.of("a", "1", "b", "2"), List.of("a", "b"));
+        ValidationReport<Map<String, String>> report = provider.validate();
+        assertTrue(report.isValid());
+        assertNull(report.getCause());
+    }
+}


### PR DESCRIPTION
## Summary
- fix `WebClientProviderWithApiKey` validation cause handling and use generics
- correct message in `JUtilsServerException`
- add unit tests for `WebClientProviderWithApiKey`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685871a92b98832ea0c0ad422afeb141